### PR TITLE
Few improvements

### DIFF
--- a/library.js
+++ b/library.js
@@ -14,9 +14,9 @@ plugin.parse = function(data, callback) {
 };
 
 plugin.parseRaw = function (content, callback) {
+	console.log(content)
 	callback(null, 
-		content.replace(/<p>! *(\((.+?)\))?([\S\s]*?)<\/p>/gm, '</blockquote><blockquote class="spoiler" data-title="$2"><p>$3</p></blockquote><blockquote>')
-		.replace(/<blockquote>\s*<\/blockquote>/g, '')
+		content.replace(/<blockquote>\s*<p>! *(\((.+?)\))?([\S\s]*?)<\/p>\s*<\/blockquote>/gm, '<blockquote class="spoiler" tabindex="-1" data-title="$2"><p>$3</p></blockquote>')
 	);
 };
 

--- a/library.js
+++ b/library.js
@@ -14,7 +14,6 @@ plugin.parse = function(data, callback) {
 };
 
 plugin.parseRaw = function (content, callback) {
-	console.log(content)
 	callback(null, 
 		content.replace(/<blockquote>\s*<p>! *(\((.+?)\))?([\S\s]*?)<\/p>\s*<\/blockquote>/gm, '<blockquote class="spoiler" tabindex="-1" data-title="$2"><p>$3</p></blockquote>')
 	);

--- a/library.js
+++ b/library.js
@@ -6,12 +6,18 @@ plugin.parse = function(data, callback) {
 	if (!data || !data.postData || !data.postData.content) {
 	    return callback(null, data);
 	}
-	// this regex could be better
-	data.postData.content = data.postData.content
-		.replace(/<p>! *([\S\s]*?)<\/p>/gm, '</blockquote><blockquote class="spoiler"><p>$1</p></blockquote><blockquote>')
-		.replace(/<blockquote>\s*<\/blockquote>/g, '');
 
-	callback(null, data);
+	plugin.parseRaw(data.postData.content, function (err, content) {
+		data.postData.content = content;
+		callback(err, data);
+	});
+};
+
+plugin.parseRaw = function (content, callback) {
+	callback(null, 
+		content.replace(/<p>! *(\((.+?)\))?([\S\s]*?)<\/p>/gm, '</blockquote><blockquote class="spoiler" data-title="$2"><p>$3</p></blockquote><blockquote>')
+		.replace(/<blockquote>\s*<\/blockquote>/g, '')
+	);
 };
 
 module.exports = plugin;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodebb-plugin-spoilers",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Spoilers for NodeBB",
   "main": "library.js",
   "scripts": {

--- a/plugin.json
+++ b/plugin.json
@@ -5,7 +5,8 @@
 	"url": "https://github.com/psychobunny/nodebb-plugin-spoilers",
 	"library": "./library.js",
 	"hooks": [
-		{ "hook": "filter:parse.post", "method": "parse", "priority": 6 }
+		{ "hook": "filter:parse.post", "method": "parse", "priority": 6 },
+		{ "hook": "filter:parse.raw", "method": "parseRaw", "priority": 6 }
 	],
 	"staticDirs": {
 		"static": "./static"

--- a/static/spoilers.js
+++ b/static/spoilers.js
@@ -1,12 +1,15 @@
 $('document').ready(function() {
 	require(['composer', 'composer/controls'], function(composer, controls) {
 		composer.addButton('fa fa-eye-slash', function(textarea, selectionStart, selectionEnd) {
+			var prefix = '>! ';
+			var title = '(Spoiler) ';
 			if(selectionStart === selectionEnd){
-				controls.insertIntoTextarea(textarea, ">! Spoiler");
-				controls.updateTextareaSelection(textarea, selectionStart + 3, selectionStart + 12);
+				var text = 'Text';
+				controls.insertIntoTextarea(textarea, prefix + title + text);
+				controls.updateTextareaSelection(textarea, selectionStart + (prefix.length + title.length), selectionStart + (prefix.length + title.length + text.length));
 			} else {
-				controls.wrapSelectionInTextareaWith(textarea, '>! ', '');
-				controls.updateTextareaSelection(textarea, selectionStart + 3, selectionEnd + 3);
+				controls.wrapSelectionInTextareaWith(textarea, prefix + title, '');
+				controls.updateTextareaSelection(textarea, selectionStart + (prefix.length + title.length), selectionEnd + (prefix.length + title.length));
 			}
 		});
 	});

--- a/static/spoilers.less
+++ b/static/spoilers.less
@@ -5,11 +5,17 @@ blockquote.spoiler {
 	p {
 		color: darken(@brand-warning, 30%);
 		opacity: 0;
-		-webkit-transition: opacity 0.5s;
-		transition: opacity 0.5s;
+		-webkit-transition: opacity 0.5s 0.5s;
+		transition: opacity 0.5s 0.5s;
 	}
 
 	&:hover p {
 		opacity: 1;
-	}	
+	}
+	
+	&:before {
+		color: @brand-warning;
+		content: attr(data-title);
+		font-size: 14px;
+	}
 }

--- a/static/spoilers.less
+++ b/static/spoilers.less
@@ -1,15 +1,15 @@
 blockquote.spoiler {
 	background: lighten(@brand-warning, 30%);
 	border-left-color: @brand-warning;
+	cursor: pointer;
+	outline: none;
 
 	p {
 		color: darken(@brand-warning, 30%);
 		opacity: 0;
-		-webkit-transition: opacity 0.5s 0.5s;
-		transition: opacity 0.5s 0.5s;
 	}
 
-	&:hover p {
+	&:focus p {
 		opacity: 1;
 	}
 	


### PR DESCRIPTION
- Add parsing to the editor’s preview (filter:parse.raw)
- Add ability to set a title for the spoiler with `>! (Title) Spoiler`

    Hidden: 
    ![](https://i.imgur.com/YRC5lQs.png) 
    Shown: 
    ![](https://i.imgur.com/JJNgiTt.png)
    (The old behaviour still works if you don't include the title between the parenthesis)
- Add 0.5s of delay before showing the spoiler to avoid viewing it by
accident